### PR TITLE
2.3.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,17 +7,17 @@
     <NuGetAuditMode>all</NuGetAuditMode>
     <!-- https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1901-nu1904 -->
     <WarningsAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
-    <AspNet8PackageVersion>8.0.22</AspNet8PackageVersion>
-    <AspNet9PackageVersion>9.0.11</AspNet9PackageVersion>
-    <AspNet10PackageVersion>10.0.1</AspNet10PackageVersion>
+    <AspNet8PackageVersion>8.0.23</AspNet8PackageVersion>
+    <AspNet9PackageVersion>9.0.12</AspNet9PackageVersion>
+    <AspNet10PackageVersion>10.0.2</AspNet10PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Condition="'$(TargetFramework)'=='net8.0'" Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNet8PackageVersion)" />
     <PackageVersion Condition="'$(TargetFramework)'=='net9.0'" Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNet9PackageVersion)" />
     <PackageVersion Condition="'$(TargetFramework)'=='net10.0'" Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNet10PackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(AspNet10PackageVersion)" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.5.0-preview.1" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.11.10" />
-    <PackageVersion Include="WeihanLi.Common" Version="1.0.85" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.6.0-preview.1" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.12.14" />
+    <PackageVersion Include="WeihanLi.Common" Version="1.0.86" />
   </ItemGroup>
 </Project>

--- a/build/version.props
+++ b/build/version.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <VersionMajor>2</VersionMajor>
-    <VersionMinor>3</VersionMinor>
-    <VersionPatch>1</VersionPatch>
+    <VersionMinor>4</VersionMinor>
+    <VersionPatch>0</VersionPatch>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>
     <VersionSuffix Condition="'$(Configuration)'=='DEBUG'">develop</VersionSuffix>
     <InformationalVersion>$(PackageVersion)</InformationalVersion>

--- a/build/version.props
+++ b/build/version.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <VersionMajor>2</VersionMajor>
-    <VersionMinor>4</VersionMinor>
-    <VersionPatch>0</VersionPatch>
+    <VersionMinor>3</VersionMinor>
+    <VersionPatch>2</VersionPatch>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>
     <VersionSuffix Condition="'$(Configuration)'=='DEBUG'">develop</VersionSuffix>
     <InformationalVersion>$(PackageVersion)</InformationalVersion>

--- a/samples/file-scripts/aot-test.cs
+++ b/samples/file-scripts/aot-test.cs
@@ -56,7 +56,7 @@ var probes = app.MapProbes("/probes");
 probes.MapGet("/live", () => Results.Ok());
 probes.MapGet("/ready", () => Results.Ok());
 
-app.Map("/basic-auth-test", (HttpContext httpContext) => $"Hello {httpContext.User.Identity?.Name}({httpContext.User.GetUserId<int>()})").RequireAuthorization();
+app.MapGet("/basic-auth-test", (HttpContext httpContext) => $"Hello {httpContext.User.Identity?.Name}({httpContext.User.GetUserId<int>()})").RequireAuthorization();
 
 app.MapOpenApi();
 app.MapScalarApiReference();


### PR DESCRIPTION
### bump dependencies

This pull request primarily updates package versions and increments the patch version for the project. There is also a minor fix to the endpoint mapping in a sample script.

Dependency and version updates:

* Updated ASP.NET package versions in `Directory.Packages.props`:
  - `AspNet8PackageVersion` to `8.0.23`
  - `AspNet9PackageVersion` to `9.0.12`
  - `AspNet10PackageVersion` to `10.0.2`
* Updated other package versions in `Directory.Packages.props`:
  - `ModelContextProtocol.AspNetCore` to `0.6.0-preview.1`
  - `Scalar.AspNetCore` to `2.12.14`
  - `WeihanLi.Common` to `1.0.86`
* Incremented patch version from `2.3.1` to `2.3.2` in `build/version.props`

Code quality fix:

* Changed the `/basic-auth-test` endpoint in `samples/file-scripts/aot-test.cs` to use `MapGet` instead of `Map`, ensuring proper HTTP method mapping